### PR TITLE
 return currency name when symbol doesn't exist

### DIFF
--- a/lib/antonienko/MoneyFormatter/MoneyFormatter.php
+++ b/lib/antonienko/MoneyFormatter/MoneyFormatter.php
@@ -28,15 +28,22 @@ class MoneyFormatter
         return $number_formatter->formatCurrency($this->getAmountInBaseUnits($money), $money->getCurrency()->getName());
     }
 
-    public function getSymbol($locale, Money $money)
+    public function getSymbol($locale, Money $money, $justSymbol = true)
     {
         $string = $this->toStringByLocale($locale, $money);
-        return preg_replace('/[a-z0-9., ]*/iu', '', $string);
+        $symbol = preg_replace('/[0-9., ]*/iu', '', $string);
+        if ($justSymbol) {
+            $symbol_tmp = preg_replace('/[a-z]+/iu','',$symbol);
+            if ('' != $symbol_tmp) {
+                $symbol = $symbol_tmp;
+            }
+        }
+        return $symbol;
     }
 
-    public function getSymbolFromCurrency($locale, Currency $currency)
+    public function getSymbolFromCurrency($locale, Currency $currency, $justSymbol = true)
     {
-        return $this->getSymbol($locale, new Money(1, $currency));
+        return $this->getSymbol($locale, new Money(1, $currency), $justSymbol);
     }
 
     public function getSymbolPosition($locale, Currency $currency)

--- a/tests/antonienko/tests/unit/MoneyFormatterTest.php
+++ b/tests/antonienko/tests/unit/MoneyFormatterTest.php
@@ -98,7 +98,40 @@ class MoneyFormatterTest extends \PHPUnit_Framework_TestCase
             array('de_DE', 'USD', '$'),
             array('en_US', 'USD', '$'),
             array('fr_FR', 'USD', '$'),
+            array('en_CA', 'CAD', '$'),
+            array('en_CA', 'USD', '$'),
+            array('de_DE', 'CHF', 'CHF'),
         );
     }
+
+    /**
+     * method getSymbol
+     * when calledWithAProperCurrencyButJustSymbolFalse
+     * should returnFullCurrencySymbol
+     * @dataProvider getLocaleCurrencyAndExpectedFullSymbol
+     */
+    public function test_getSymbol_calledWithAProperCurrencyButJustSymbolFalse_returnFullCurrencySymbol($locale, $currency, $expected)
+    {
+        $sut = new MoneyFormatter();
+        $actual = $sut->getSymbol($locale, new Money(300005, new Currency($currency)), false);
+        $this->assertEquals($expected, $actual, 'Test failed for locale '.$locale.' and currency '.$currency);
+    }
+
+    public function getLocaleCurrencyAndExpectedFullSymbol()
+    {
+        return array(
+            array('de_DE', 'EUR', '€'),
+            array('en_US', 'EUR', '€'),
+            array('fr_FR', 'EUR', '€'),
+            array('de_DE', 'USD', '$'),
+            array('en_US', 'USD', '$'),
+            array('fr_FR', 'USD', '$US'),
+            array('en_CA', 'CAD', '$'),
+            array('en_CA', 'USD', 'US$'),
+            array('en_US', 'CAD', 'CA$'),
+            array('de_DE', 'CHF', 'CHF'),
+        );
+    }
+
 
 }


### PR DESCRIPTION
Depending on the combination between the currency and locale, not returns a symbol. For these cases, return the name of the currency.
